### PR TITLE
Connect portfolio to e‑commerce demo and add backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 This project contains a minimal example of a client-side e-commerce website. It is located in the `ecommerce` directory and includes a product list, cart functionality stored in `localStorage`, and a placeholder checkout action. The site is purely static and does not include payment processing or server-side code.
 
+The repository also includes a basic ASP.NET Core backend in `ecommerce-backend`.
+This backend exposes a simple `/api/products` endpoint returning the sample
+product list. You can extend it and connect a database as needed.
+
 ## Files
 - `index.html` – product listing
 - `cart.html` – displays items added to the cart

--- a/ecommerce-backend/Program.cs
+++ b/ecommerce-backend/Program.cs
@@ -1,0 +1,32 @@
+var builder = WebApplication.CreateBuilder(args);
+
+// Add services for minimal API and Swagger
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
+
+// Temporary in-memory product list. Replace with database logic as needed.
+var products = new List<Product>
+{
+    new Product(1, "Item A", 25M),
+    new Product(2, "Item B", 30M),
+    new Product(3, "Item C", 45M)
+};
+
+var app = builder.Build();
+
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+
+app.UseHttpsRedirection();
+
+// GET /api/products - list all products
+app.MapGet("/api/products", () => products);
+
+// Additional endpoints can be added here (e.g. cart management)
+
+app.Run();
+
+record Product(int Id, string Name, decimal Price);

--- a/ecommerce-backend/Properties/launchSettings.json
+++ b/ecommerce-backend/Properties/launchSettings.json
@@ -1,0 +1,41 @@
+﻿{
+  "$schema": "http://json.schemastore.org/launchsettings.json",
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:22263",
+      "sslPort": 44378
+    }
+  },
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "applicationUrl": "http://localhost:5055",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "applicationUrl": "https://localhost:7006;http://localhost:5055",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/ecommerce-backend/README.md
+++ b/ecommerce-backend/README.md
@@ -1,0 +1,15 @@
+# E-commerce Backend
+
+This ASP.NET Core project provides a simple API for the demo e-commerce site.
+The sample `Program.cs` exposes a `/api/products` endpoint returning an
+in-memory list of items. Configure additional endpoints and database logic as
+needed.
+
+## Running
+
+```bash
+cd ecommerce-backend
+dotnet run
+```
+
+The API will listen on `https://localhost:5001` by default when run locally.

--- a/ecommerce-backend/appsettings.Development.json
+++ b/ecommerce-backend/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/ecommerce-backend/appsettings.json
+++ b/ecommerce-backend/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/ecommerce-backend/ecommerce-backend.csproj
+++ b/ecommerce-backend/ecommerce-backend.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <RootNamespace>ecommerce_backend</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.16" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
+  </ItemGroup>
+
+</Project>

--- a/ecommerce-backend/ecommerce-backend.http
+++ b/ecommerce-backend/ecommerce-backend.http
@@ -1,0 +1,6 @@
+@ecommerce_backend_HostAddress = http://localhost:5055
+
+GET {{ecommerce_backend_HostAddress}}/weatherforecast/
+Accept: application/json
+
+###

--- a/index.html
+++ b/index.html
@@ -148,7 +148,7 @@
                 </div>
                 <!-- Project 2 -->
                 <div class="project">
-                    <h3>E-Commerce Platform</h3>
+                    <h3><a href="ecommerce/index.html">E-Commerce Platform</a></h3>
                     <p>Developed a responsive e-commerce solution with secure payment integration, user authentication, and inventory management features.</p>
                     <div class="project-tech">
                         <span>Frontend</span>


### PR DESCRIPTION
## Summary
- link the "E-Commerce Platform" project on the portfolio page to the demo store
- document the new backend in the main README
- create an ASP.NET Core API backend under `ecommerce-backend`
- document how to run the backend

## Testing
- `dotnet build ecommerce-backend`

------
https://chatgpt.com/codex/tasks/task_e_683fe41a5828832082b0067c0aeb1b78