### PR TITLE
Add MudBlazor ecommerce template

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,6 @@ product list. You can extend it and connect a database as needed.
 
 ## Running
 Open `ecommerce/index.html` in any modern browser to view the store. Cart contents persist in the browser using `localStorage`.
+
+## MudBlazor Ecommerce (Login First)
+A simple Blazor Server app using MudBlazor components is available in the `mudblazor-ecommerce` folder. The application starts on the login page (`/`) and navigates to the product listing after successful login.

--- a/mudblazor-ecommerce/App.razor
+++ b/mudblazor-ecommerce/App.razor
@@ -1,0 +1,13 @@
+<CascadingAuthenticationState>
+    <Router AppAssembly="typeof(Program).Assembly">
+        <Found Context="routeData">
+            <RouteView RouteData="routeData" DefaultLayout="typeof(MainLayout)" />
+            <FocusOnNavigate RouteData="routeData" Selector="h1" />
+        </Found>
+        <NotFound>
+            <LayoutView Layout="typeof(MainLayout)">
+                <p>Sorry, there's nothing at this address.</p>
+            </LayoutView>
+        </NotFound>
+    </Router>
+</CascadingAuthenticationState>

--- a/mudblazor-ecommerce/Pages/Index.razor
+++ b/mudblazor-ecommerce/Pages/Index.razor
@@ -1,0 +1,26 @@
+@page "/index"
+@inject NavigationManager Nav
+@inject AuthenticationStateProvider AuthProvider
+
+<h1>Products</h1>
+
+<AuthorizeView>
+    <Authorized>
+        <MudText>Welcome!</MudText>
+        <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="Logout">Logout</MudButton>
+    </Authorized>
+    <NotAuthorized>
+        @Nav.NavigateTo("login", true)
+    </NotAuthorized>
+</AuthorizeView>
+
+@code {
+    private async Task Logout()
+    {
+        if (AuthProvider is SimpleAuthStateProvider provider)
+        {
+            provider.SignOut();
+            Nav.NavigateTo("login", true);
+        }
+    }
+}

--- a/mudblazor-ecommerce/Pages/Login.razor
+++ b/mudblazor-ecommerce/Pages/Login.razor
@@ -1,0 +1,23 @@
+@page "/"
+@inject NavigationManager Nav
+@inject AuthenticationStateProvider AuthProvider
+
+<MudPaper Class="pa-4 mx-auto" MaxWidth="300px">
+    <MudTextField @bind-Value="email" Label="Email" Variant="Variant.Outlined" />
+    <MudTextField @bind-Value="password" Label="Password" Variant="Variant.Outlined" InputType="InputType.Password" />
+    <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="HandleLogin">Login</MudButton>
+</MudPaper>
+
+@code {
+    private string email = string.Empty;
+    private string password = string.Empty;
+
+    private void HandleLogin()
+    {
+        if (AuthProvider is SimpleAuthStateProvider provider)
+        {
+            provider.SignIn(email);
+            Nav.NavigateTo("index", true);
+        }
+    }
+}

--- a/mudblazor-ecommerce/Pages/Shared/_Layout.cshtml
+++ b/mudblazor-ecommerce/Pages/Shared/_Layout.cshtml
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>@ViewData["Title"] - MudBlazor Ecommerce</title>
+    <link href="css/site.css" rel="stylesheet" />
+    <link href="_content/MudBlazor/MudBlazor.min.css" rel="stylesheet" />
+</head>
+<body>
+    <header></header>
+    <main role="main" class="container">
+        @RenderBody()
+    </main>
+    <script src="_content/MudBlazor/MudBlazor.min.js"></script>
+    @RenderSection("Scripts", required: false)
+</body>
+</html>

--- a/mudblazor-ecommerce/Pages/_Host.cshtml
+++ b/mudblazor-ecommerce/Pages/_Host.cshtml
@@ -1,0 +1,23 @@
+@page "/"
+@namespace mudblazor_ecommerce.Pages
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
+@{
+    Layout = null;
+}
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>MudBlazor Ecommerce</title>
+    <base href="~/" />
+    <link href="css/site.css" rel="stylesheet" />
+    <link href="_content/MudBlazor/MudBlazor.min.css" rel="stylesheet" />
+</head>
+<body>
+    <app>
+        <component type="typeof(App)" render-mode="ServerPrerendered" />
+    </app>
+    <script src="_framework/blazor.server.js"></script>
+</body>
+</html>

--- a/mudblazor-ecommerce/Pages/_ViewImports.cshtml
+++ b/mudblazor-ecommerce/Pages/_ViewImports.cshtml
@@ -1,0 +1,2 @@
+@using mudblazor_ecommerce
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers

--- a/mudblazor-ecommerce/Pages/_ViewStart.cshtml
+++ b/mudblazor-ecommerce/Pages/_ViewStart.cshtml
@@ -1,0 +1,3 @@
+@{
+    Layout = "_Layout";
+}

--- a/mudblazor-ecommerce/Program.cs
+++ b/mudblazor-ecommerce/Program.cs
@@ -1,0 +1,30 @@
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Authorization;
+using Microsoft.AspNetCore.Components.Web;
+using MudBlazor.Services;
+using mudblazor_ecommerce.Services;
+
+var builder = WebApplication.CreateBuilder(args);
+
+// Add services to the container.
+builder.Services.AddRazorPages();
+builder.Services.AddServerSideBlazor();
+builder.Services.AddMudServices();
+builder.Services.AddScoped<AuthenticationStateProvider, SimpleAuthStateProvider>();
+
+var app = builder.Build();
+
+if (!app.Environment.IsDevelopment())
+{
+    app.UseExceptionHandler("/Error");
+    app.UseHsts();
+}
+
+app.UseHttpsRedirection();
+app.UseStaticFiles();
+app.UseRouting();
+
+app.MapBlazorHub();
+app.MapFallbackToPage("/_Host");
+
+app.Run();

--- a/mudblazor-ecommerce/README.md
+++ b/mudblazor-ecommerce/README.md
@@ -1,0 +1,10 @@
+# MudBlazor Ecommerce
+
+This is a minimal Blazor Server application using MudBlazor components. The app starts on a login page and requires authentication before navigating to the product listing page.
+
+Since the environment does not include the .NET SDK, the project files are provided as a template. You can build and run it locally with .NET 6 installed:
+
+```bash
+dotnet restore
+dotnet run
+```

--- a/mudblazor-ecommerce/Services/SimpleAuthStateProvider.cs
+++ b/mudblazor-ecommerce/Services/SimpleAuthStateProvider.cs
@@ -1,0 +1,27 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Components.Authorization;
+
+namespace mudblazor_ecommerce.Services;
+
+public class SimpleAuthStateProvider : AuthenticationStateProvider
+{
+    private ClaimsPrincipal _currentUser = new ClaimsPrincipal(new ClaimsIdentity());
+
+    public override Task<AuthenticationState> GetAuthenticationStateAsync()
+    {
+        return Task.FromResult(new AuthenticationState(_currentUser));
+    }
+
+    public void SignIn(string email)
+    {
+        var identity = new ClaimsIdentity(new[] { new Claim(ClaimTypes.Name, email) }, "FakeAuth");
+        _currentUser = new ClaimsPrincipal(identity);
+        NotifyAuthenticationStateChanged(GetAuthenticationStateAsync());
+    }
+
+    public void SignOut()
+    {
+        _currentUser = new ClaimsPrincipal(new ClaimsIdentity());
+        NotifyAuthenticationStateChanged(GetAuthenticationStateAsync());
+    }
+}

--- a/mudblazor-ecommerce/Shared/MainLayout.razor
+++ b/mudblazor-ecommerce/Shared/MainLayout.razor
@@ -1,0 +1,10 @@
+@inherits LayoutComponentBase
+
+<MudLayout>
+    <MudAppBar Color="Color.Primary" Elevation="4">
+        <MudText Typo="Typo.h6">MudBlazor Ecommerce</MudText>
+    </MudAppBar>
+    <MudMainContent>
+        @Body
+    </MudMainContent>
+</MudLayout>

--- a/mudblazor-ecommerce/_Imports.razor
+++ b/mudblazor-ecommerce/_Imports.razor
@@ -1,0 +1,9 @@
+@using System.Net.Http
+@using Microsoft.AspNetCore.Authorization
+@using Microsoft.AspNetCore.Components.Authorization
+@using Microsoft.AspNetCore.Components.Forms
+@using Microsoft.AspNetCore.Components.Routing
+@using Microsoft.AspNetCore.Components.Web
+@using Microsoft.JSInterop
+@using MudBlazor
+@using mudblazor_ecommerce

--- a/mudblazor-ecommerce/mudblazor-ecommerce.csproj
+++ b/mudblazor-ecommerce/mudblazor-ecommerce.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="MudBlazor" Version="6.0.2" />
+  </ItemGroup>
+</Project>

--- a/mudblazor-ecommerce/wwwroot/css/site.css
+++ b/mudblazor-ecommerce/wwwroot/css/site.css
@@ -1,0 +1,1 @@
+body { margin: 0; font-family: sans-serif; }


### PR DESCRIPTION
## Summary
- add `mudblazor-ecommerce` sample that starts on a login page
- document the new MudBlazor project

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fe7d08e608320beb846823ba8d6c1